### PR TITLE
Update gv to table

### DIFF
--- a/R/gv_to_table.R
+++ b/R/gv_to_table.R
@@ -222,8 +222,8 @@ gv_to_table <- function(gv_file, detail) {
     
   }
   
-  # split edge lines by "[label="
-  edges_section_split <- strsplit(edges_section, " \\[label=")
+  # split edge lines by "label="
+  edges_section_split <- strsplit(edges_section, " \\label=")
   
   # get the edge routes
   edges_direction <- sapply(edges_section_split, "[", 1)

--- a/R/gv_to_table.R
+++ b/R/gv_to_table.R
@@ -238,9 +238,11 @@ gv_to_table <- function(gv_file, detail) {
   
   # get to and form nodes for each edge
   edges_direction_from <- sapply(edges_direction_split, "[", 1)
-
   edges_direction_to <- sapply(edges_direction_split, "[", 2)
 
+  # split by " " and take the first part
+  edges_direction_to <- sapply(strsplit(edges_direction_to, " "), "[", 1)
+  
   # assumes there are only two splits per node
   if (any(table(edges_direction_from) != 2)) {
 


### PR DESCRIPTION
Versions of h2o after 3.16.0.2 (noticed around 3.20.0.8) include 'fontsize=' sections within the lines of the /* Edges */ section of .gv files (this section describes which nodes in the trees connect to which others, in which direction).
This changes allows the gv_to_table function to work with these changes.